### PR TITLE
Bump the dependency on Aeson.

### DIFF
--- a/src/Data/Unjson.hs
+++ b/src/Data/Unjson.hs
@@ -147,9 +147,9 @@ module Data.Unjson
 )
 where
 
-import qualified Data.Aeson as Aeson hiding (encode)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Text as Aeson
 import qualified Data.Aeson.Types as Aeson
-import qualified Data.Aeson.Encode as Aeson
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Lazy.Builder as Builder
 import qualified Data.Text as Text
@@ -172,13 +172,11 @@ import Data.Maybe
 import Data.Primitive.Types
 import Data.Hashable
 import Data.Scientific
-#ifdef MIN_VERSION_attoparsec
-#if MIN_VERSION_attoparsec(0,14,0)
-    -- do nothing
-#else
-import Data.Attoparsec.Number
-#endif
-#endif
+-- #ifdef MIN_VERSION_attoparsec
+-- #if !MIN_VERSION_attoparsec(0,14,0)
+-- import Data.Attoparsec.Number
+-- #endif
+-- #endif
 import Data.Time.LocalTime
 import Data.Time.Clock
 import Data.Fixed
@@ -321,10 +319,10 @@ class Unjson a where
   -- 'UnjsonDef'.
   unjsonDef :: UnjsonDef a
 
-instance (Unjson a) => Unjson [a] where
+instance {-# OVERLAPPABLE #-} (Unjson a) => Unjson [a] where
   unjsonDef = arrayOf unjsonDef
 
-instance Unjson String where
+instance {-# INCOHERENT #-} Unjson String where
   unjsonDef = unjsonAesonWithDoc "String"
 
 instance Unjson Bool             where unjsonDef = unjsonAeson
@@ -344,19 +342,8 @@ instance Unjson Word32           where unjsonDef = unjsonAeson
 instance Unjson Word64           where unjsonDef = unjsonAeson
 instance Unjson ()               where unjsonDef = unjsonAeson
 instance Unjson Text.Text        where unjsonDef = unjsonAeson
-#ifdef MIN_VERSION_attoparsec
-#if MIN_VERSION_attoparsec(0,14,0)
-    -- do nothing
-#else
-instance Unjson Number           where unjsonDef = unjsonAeson
-#endif
-#endif
 instance Unjson IntSet.IntSet    where unjsonDef = unjsonAeson
-#ifdef MIN_VERSION_aeson
-#if MIN_VERSION_aeson(0,7,0)
 instance Unjson Scientific       where unjsonDef = unjsonAeson
-#endif
-#endif
 instance Unjson LazyText.Text    where unjsonDef = unjsonAeson
 instance Unjson ZonedTime        where unjsonDef = unjsonAeson
 instance Unjson UTCTime          where unjsonDef = unjsonAeson

--- a/unjson.cabal
+++ b/unjson.cabal
@@ -1,5 +1,5 @@
 name:                unjson
-version:             0.14.1.1
+version:             0.14.1.2
 synopsis:            Bidirectional JSON parsing and generation.
 description:         Bidirectional JSON parsing and generation
                      with automatic documentation support.
@@ -25,57 +25,55 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/scrive/unjson.git
-  tag:      0.14.1.1
+  tag:      0.14.1.2
 
 library
   exposed-modules:     Data.Unjson
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >= 4.5 && < 5, text, aeson >= 0.7 && < 1.1,
+  build-depends:       base >= 4.5 && < 5, text, aeson >= 1.0 && < 1.2,
                        free, scientific, attoparsec,
                        unordered-containers, vector, pretty,
                        bytestring >= 0.10, containers, hashable,
                        primitive, time, invariant
   hs-source-dirs:      src
   default-language:    Haskell2010
-  default-extensions:  DeriveDataTypeable,
-                       OverloadedStrings,
+  default-extensions:  BangPatterns,
+                       DeriveDataTypeable,
                        DeriveFunctor,
                        ExtendedDefaultRules,
-                       GeneralizedNewtypeDeriving,
-                       RankNTypes,
                        FlexibleContexts,
                        FlexibleInstances,
-                       TypeFamilies,
+                       GADTs,
+                       GeneralizedNewtypeDeriving,
                        OverloadedStrings,
-                       UndecidableInstances,
+                       RankNTypes,
                        ScopedTypeVariables,
-                       OverlappingInstances,
-                       BangPatterns,
-                       GADTs
+                       TypeFamilies,
+                       UndecidableInstances
 
 Test-Suite test
   type:                exitcode-stdio-1.0
   main-is:             Test.hs
   hs-source-dirs:      src, test
-  build-depends:       base >= 4.5 && < 5, text, aeson >= 1.0 && < 1.1,
+  build-depends:       base >= 4.5 && < 5, text, aeson >= 1.0 && < 1.2,
                        free, scientific, attoparsec,
                        unordered-containers, vector, HUnit, bytestring >= 0.10,
                        pretty, primitive, containers, time,
                        hashable, invariant
   default-language:    Haskell2010
-  default-extensions:  DeriveDataTypeable,
-                       OverloadedStrings,
-                       GeneralizedNewtypeDeriving,
+  default-extensions:  BangPatterns,
+                       DeriveDataTypeable,
                        DeriveFunctor,
                        ExtendedDefaultRules,
-                       RankNTypes,
-                       UndecidableInstances,
                        FlexibleContexts,
                        FlexibleInstances,
-                       TypeFamilies,
-                       OverloadedStrings,
-                       ScopedTypeVariables,
+                       GADTs,
+                       GeneralizedNewtypeDeriving,
                        OverlappingInstances,
-                       BangPatterns,
-                       GADTs
+                       OverloadedStrings,
+                       OverloadedStrings,
+                       RankNTypes,
+                       ScopedTypeVariables,
+                       TypeFamilies,
+                       UndecidableInstances


### PR DESCRIPTION
Also stop using the deprecated `OverlappingInstances` extension. Took me some time to figure out that I needed the `INCOHERENT` pragma...

Tested that it works both with the latest `aeson` version and 1.0.0.0. Support for pre-1.0 can be safely dropped, I think.