### PR TITLE
Implement new semantics for array update.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 /dist-newstyle/
 /dist/
-cabal.project.local
+/.stack-work/
+/cabal.project.local
+/cabal.project.local~
+/cabal.project.freeze
 /TAGS
-.stack-work
-.ghc.environment.*
-cabal.project.local~
+/.ghc.environment.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,31 @@
+# unjson-0.15.0.0 (2018-??-??)
+* Semantics change: 'update' of an array inside of an object now does
+  proper recursive update/merge instead of replace (#5).
+
 # unjson-0.15.0.0 (2018-02-22)
 * Breaking change: Unjson definitions now require the underlying types
   to have Typeable instances ([#6](https://github.com/scrive/unjson/pull/6)).
 * Added a way to automatically derive Unjson definitions for
   parameterless sum types (`enumUnjsonDef`) ([#7](https://github.com/scrive/unjson/pull/7)).
 * Dropped support for GHC < 7.8.
+
+# unjson-0.14.1.3 (2017-04-24)
+* Bumped the dependency on aeson
+* Fixed the test suite on GHC 7.10.3
+
+# unjson-0.14.1.2 (2017-04-11)
+* Bumped the dependency on aeson
+
+# unjson-0.14.1.1 (2017-02-28)
+* Adjusting tests
+
+# unjson-0.14.1.0 (2017-02-28)
+* Changed (>>=) to prevent error unpacking
+
+# unjson-0.14.0.1 (2016-09-21)
+* add README.md to extra-source-files
+* relax the constraint on aeson
+
+# unjson-0.14 (2016-09-21)
+* initial release
+* fix compilation with aeson-1.0

--- a/src/Data/Unjson.hs
+++ b/src/Data/Unjson.hs
@@ -319,7 +319,7 @@ class Unjson a where
   unjsonDef :: UnjsonDef a
 
 #if __GLASGOW_HASKELL__ < 710
-instance (Unjson a) => Unjson [a] where
+instance (Unjson a, Typeable a) => Unjson [a] where
 #else
 instance {-# OVERLAPPABLE #-} (Unjson a, Typeable a) => Unjson [a] where
 #endif

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -793,21 +793,21 @@ test_readonly_fields = "test_readonly_fields" ~: do
 
 data D1 = D1 { sign_order :: Int
              , other_field :: Int
-             } deriving (Eq, Show)
+             } deriving (Eq, Show, Typeable)
 
 instance Default D1 where
   def = D1 1 0
 
 data D2 = D2 { title   :: String
              , parties :: [D1]
-             } deriving (Eq, Show)
+             } deriving (Eq, Show, Typeable)
 
 instance Default D2 where
   def = D2 "" []
 
 data D3 = D3 { d3Title  :: String
              , d3IntArr :: [Int]
-             } deriving (Eq, Show)
+             } deriving (Eq, Show, Typeable)
 
 instance Default D3 where
   def = D3 "" []

--- a/unjson.cabal
+++ b/unjson.cabal
@@ -56,7 +56,7 @@ Test-Suite test
   type:                exitcode-stdio-1.0
   main-is:             Test.hs
   hs-source-dirs:      test
-  build-depends:       unjson, base, text, aeson,
+  build-depends:       unjson, base, data-default, text, aeson,
                        free, scientific, attoparsec,
                        unordered-containers, vector, HUnit, bytestring >= 0.10,
                        pretty, primitive, containers, time,


### PR DESCRIPTION
Previously, calling `update` on an array simply created a new array with new contents. Now we try to update the old array recursively.

[Case 3261](https://scrive.fogbugz.com/f/cases/edit/3261/Deeper-substructure-update-in-api-v1-vs-v2).

@Paczesiowa, please take a look at the new test case I added and tell me whether the new semantics does what you want. 