### PR TITLE
Add Typeable constraints to Unjson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /dist/
 cabal.project.local
 /TAGS
+.stack-work

--- a/src/Data/Unjson.hs
+++ b/src/Data/Unjson.hs
@@ -634,10 +634,10 @@ contramapTupleFieldDef f (TupleFieldDef i e d) = TupleFieldDef i (e . f) d
 -- parsing definition.  'FieldDef' has three cases for fields that are
 -- required, optional (via 'Maybe') or jave default value.
 data FieldDef s a where
-  FieldReqDef :: Text.Text -> Text.Text -> (s -> a) -> UnjsonDef a -> FieldDef s a
-  FieldOptDef :: Text.Text -> Text.Text -> (s -> Maybe a) -> UnjsonDef a -> FieldDef s (Maybe a)
-  FieldDefDef :: Text.Text -> Text.Text -> a -> (s -> a) -> UnjsonDef a -> FieldDef s a
-  FieldRODef  :: Text.Text -> Text.Text -> (s -> a) -> UnjsonDef a -> FieldDef s ()
+  FieldReqDef :: Typeable a => Text.Text -> Text.Text -> (s -> a)       -> UnjsonDef a -> FieldDef s a
+  FieldOptDef :: Typeable a => Text.Text -> Text.Text -> (s -> Maybe a) -> UnjsonDef a -> FieldDef s (Maybe a)
+  FieldDefDef :: Typeable a => Text.Text -> Text.Text -> a -> (s -> a)  -> UnjsonDef a -> FieldDef s a
+  FieldRODef  :: Typeable a => Text.Text -> Text.Text -> (s -> a)       -> UnjsonDef a -> FieldDef s ()
 
 -- | Define a tuple element. 'TupleFieldDef' holds information about
 -- index, accessor function and a parser definition.
@@ -1021,7 +1021,7 @@ lookupByTupleFieldDef v ov (TupleFieldDef idx f valuedef)
 -- >
 -- > data Thing = Thing { thingCredentials :: Credentials, ... }
 -- > unjsonCredentials :: UnjsonDef Credentials
-fieldBy :: Text.Text -> (s -> a) -> Text.Text -> UnjsonDef a -> Ap (FieldDef s) a
+fieldBy :: Typeable a => Text.Text -> (s -> a) -> Text.Text -> UnjsonDef a -> Ap (FieldDef s) a
 fieldBy key f docstring valuedef = liftAp (FieldReqDef key docstring f valuedef)
 
 -- | Declare a required field with definition from 'Unjson' typeclass.
@@ -1036,7 +1036,7 @@ fieldBy key f docstring valuedef = liftAp (FieldReqDef key docstring f valuedef)
 -- >
 -- > data Thing = Thing { thingCredentials :: Credentials, ... }
 -- > instance Unjson Credentials where ...
-field :: (Unjson a) => Text.Text -> (s -> a) -> Text.Text -> Ap (FieldDef s) a
+field :: (Unjson a, Typeable a) => Text.Text -> (s -> a) -> Text.Text -> Ap (FieldDef s) a
 field key f docstring = fieldBy key f docstring unjsonDef
 
 -- | Declare an optional field and definition by valuedef.
@@ -1052,7 +1052,7 @@ field key f docstring = fieldBy key f docstring unjsonDef
 -- >
 -- > data Thing = Thing { thingCredentials :: Credentials, ... }
 -- > unjsonCredentials :: UnjsonDef Credentials
-fieldOptBy :: Text.Text -> (s -> Maybe a) -> Text.Text -> UnjsonDef a -> Ap (FieldDef s) (Maybe a)
+fieldOptBy :: Typeable a => Text.Text -> (s -> Maybe a) -> Text.Text -> UnjsonDef a -> Ap (FieldDef s) (Maybe a)
 fieldOptBy key f docstring valuedef = liftAp (FieldOptDef key docstring f valuedef)
 
 -- | Declare an optional field and definition by 'Unjson' typeclass.
@@ -1067,7 +1067,7 @@ fieldOptBy key f docstring valuedef = liftAp (FieldOptDef key docstring f valued
 -- >
 -- > data Thing = Thing { thingCredentials :: Credentials, ... }
 -- > instance Unjson Credentials where ...
-fieldOpt :: (Unjson a) => Text.Text -> (s -> Maybe a) -> Text.Text -> Ap (FieldDef s) (Maybe a)
+fieldOpt :: (Unjson a, Typeable a) => Text.Text -> (s -> Maybe a) -> Text.Text -> Ap (FieldDef s) (Maybe a)
 fieldOpt key f docstring = fieldOptBy key f docstring unjsonDef
 
 -- | Declare a field with default value and definition by valuedef.
@@ -1083,7 +1083,7 @@ fieldOpt key f docstring = fieldOptBy key f docstring unjsonDef
 -- >
 -- > data Thing = Thing { thingCredentials :: Credentials, ... }
 -- > unjsonCredentials :: UnjsonDef Credentials
-fieldDefBy :: Text.Text -> a -> (s -> a) -> Text.Text -> UnjsonDef a -> Ap (FieldDef s) a
+fieldDefBy :: Typeable a => Text.Text -> a -> (s -> a) -> Text.Text -> UnjsonDef a -> Ap (FieldDef s) a
 fieldDefBy key def f docstring valuedef = liftAp (FieldDefDef key docstring def f valuedef)
 
 -- | Declare a field with default value and definition by 'Unjson' typeclass.
@@ -1097,7 +1097,7 @@ fieldDefBy key def f docstring valuedef = liftAp (FieldDefDef key docstring def 
 -- >          "Port to listen on, defaults to 80"
 -- >
 -- > data Thing = Thing { thingPort :: Int, ... }
-fieldDef :: (Unjson a) => Text.Text -> a -> (s -> a) -> Text.Text -> Ap (FieldDef s) a
+fieldDef :: (Unjson a, Typeable a) => Text.Text -> a -> (s -> a) -> Text.Text -> Ap (FieldDef s) a
 fieldDef key def f docstring = fieldDefBy key def f docstring unjsonDef
 
 
@@ -1116,7 +1116,7 @@ fieldDef key def f docstring = fieldDefBy key def f docstring unjsonDef
 -- >          "Additional string"
 -- >
 -- > data Thing = Thing { thingPort :: Int, thingString :: String, ... }
-fieldReadonly :: (Unjson a) => Text.Text -> (s -> a) -> Text.Text ->  Ap (FieldDef s) ()
+fieldReadonly :: (Unjson a, Typeable a) => Text.Text -> (s -> a) -> Text.Text ->  Ap (FieldDef s) ()
 fieldReadonly key f docstring = fieldReadonlyBy key f docstring unjsonDef
 
 -- | Declare a field that is readonly from the point of view of Haskell structures,
@@ -1136,7 +1136,7 @@ fieldReadonly key f docstring = fieldReadonlyBy key f docstring unjsonDef
 -- >          "Additional string"
 -- >
 -- > data Thing = Thing { thingPort :: Port, thingString :: String, ... }
-fieldReadonlyBy ::  Text.Text -> (s -> a) -> Text.Text -> UnjsonDef a -> Ap (FieldDef s) ()
+fieldReadonlyBy :: Typeable a => Text.Text -> (s -> a) -> Text.Text -> UnjsonDef a -> Ap (FieldDef s) ()
 fieldReadonlyBy key f docstring valuedef = liftAp (FieldRODef key docstring f valuedef)
 
 -- | Declare an object as bidirectional mapping from JSON object to Haskell record and back.

--- a/src/Data/Unjson.hs
+++ b/src/Data/Unjson.hs
@@ -383,25 +383,25 @@ instance (Prim a, Unjson a) => Unjson (Data.Vector.Primitive.Vector a)
 mapFst :: (a -> c) -> (a,b) -> (c,b)
 mapFst f (a,b) = (f a, b)
 
-instance Unjson v => Unjson (Map.Map String v)
+instance (Typeable v, Unjson v) => Unjson (Map.Map String v)
   where unjsonDef = invmap (Map.fromList . map (mapFst Text.unpack) . HashMap.toList)
                                      (HashMap.fromList . map (mapFst Text.pack) . Map.toList)
                                      unjsonDef
-instance Unjson v => Unjson (Map.Map Text.Text v)
+instance (Typeable v, Unjson v) => Unjson (Map.Map Text.Text v)
   where unjsonDef = invmap (Map.fromList . HashMap.toList)
                                      (HashMap.fromList . Map.toList)
                                      unjsonDef
-instance Unjson v => Unjson (Map.Map LazyText.Text v)
+instance (Typeable v, Unjson v) => Unjson (Map.Map LazyText.Text v)
   where unjsonDef = invmap (Map.fromList . map (mapFst LazyText.fromStrict) . HashMap.toList)
                                      (HashMap.fromList . map (mapFst LazyText.toStrict) . Map.toList)
                                      unjsonDef
-instance Unjson v => Unjson (HashMap.HashMap String v)
+instance (Typeable v, Unjson v) => Unjson (HashMap.HashMap String v)
   where unjsonDef = invmap (HashMap.fromList . map (mapFst Text.unpack) . HashMap.toList)
                                      (HashMap.fromList . map (mapFst Text.pack) . HashMap.toList)
                                      unjsonDef
-instance Unjson v => Unjson (HashMap.HashMap Text.Text v)
+instance (Typeable v, Unjson v) => Unjson (HashMap.HashMap Text.Text v)
   where unjsonDef = MapUnjsonDef unjsonDef pure id
-instance Unjson v => Unjson (HashMap.HashMap LazyText.Text v)
+instance (Typeable v, Unjson v) => Unjson (HashMap.HashMap LazyText.Text v)
   where unjsonDef = invmap (HashMap.fromList . map (mapFst LazyText.fromStrict) . HashMap.toList)
                                      (HashMap.fromList . map (mapFst LazyText.toStrict) . HashMap.toList)
                                      unjsonDef
@@ -595,7 +595,7 @@ data UnjsonDef a where
   TupleUnjsonDef    :: Ap (TupleFieldDef k) (Result k) -> UnjsonDef k
   DisjointUnjsonDef :: Text.Text -> [(Text.Text, k -> Bool, Ap (FieldDef k) (Result k))] -> UnjsonDef k
   UnionUnjsonDef    :: [(k -> Bool, Ap (FieldDef k) (Result k))] -> UnjsonDef k
-  MapUnjsonDef      :: UnjsonDef k -> (HashMap.HashMap Text.Text k -> Result v) -> (v -> HashMap.HashMap Text.Text k) -> UnjsonDef v
+  MapUnjsonDef      :: Typeable k => UnjsonDef k -> (HashMap.HashMap Text.Text k -> Result v) -> (v -> HashMap.HashMap Text.Text k) -> UnjsonDef v
 
 instance Invariant UnjsonDef where
   invmap f g (SimpleUnjsonDef name p s) = SimpleUnjsonDef name (fmap f . p) (s . g)
@@ -1173,7 +1173,7 @@ objectOf fields = ObjectUnjsonDef (fmap pure fields)
 -- > objectOf $ pure X
 -- >   <*> field "xmap" xMap
 -- >       "Map string to Y value"
-mapOf :: UnjsonDef x -> UnjsonDef (LazyHashMap.HashMap Text.Text x)
+mapOf :: Typeable x => UnjsonDef x -> UnjsonDef (LazyHashMap.HashMap Text.Text x)
 mapOf def = MapUnjsonDef def pure id
 
 -- | Provide sum type support. Bidirectional case matching in Haskell

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,10 @@
+resolver: lts-9.9
+packages:
+- '.'
+nix:
+  enable: false
+  packages:
+  - ncurses
+  - libcxx
+  - icu
+  - gcc

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -621,12 +621,12 @@ test_maps = "test_maps" ~: do
                ]
       jsonEmbedded = Aeson.object
                      [ "a_map" .= json ]
-  let unjsonMapByInstance :: (Unjson a) => UnjsonDef a
+  let unjsonMapByInstance :: (Unjson a, Typeable a) => UnjsonDef a
       unjsonMapByInstance = objectOf $ pure id
          <*> field "a_map"
              id
              "The only map"
-  let unjsonMapByExplicit :: (Unjson a) => UnjsonDef (HashMap.HashMap Text.Text a)
+  let unjsonMapByExplicit :: (Unjson a, Typeable a) => UnjsonDef (HashMap.HashMap Text.Text a)
       unjsonMapByExplicit = objectOf $ pure id
          <*> fieldBy "a_map"
              id


### PR DESCRIPTION
### Problem
We wanted to generate Swagger Schemas from Unjson definitions (that is, without typing them by hand), but needed a way to name schemas so that we could use [References](https://swagger.io/docs/specification/using-ref/) - otherwise, in case of nested objects, there is no way to tell a traversal "ok this schema is named, stop here and insert a reference".

### Solution
This PR adds the `Typeable` constraint to `Unjson` instances.
With `Typeable`, we can get the name of the type, add it to our "schemas" context, and use this information to add References in other Schemas that include it.

### Example
How we use the `Typeable` constraint in `Data.Unjson.Swagger`:
```haskell
typeNamedSchema :: forall a. Typeable a => UnjsonDef a -> Schema -> NamedSchema
typeNamedSchema = NamedSchema . Just . unjsonDefName

unjsonDefName :: forall a. Typeable a => UnjsonDef a -> Text
unjsonDefName = Text.pack . show . unjsonDefType

unjsonDefType :: forall a. Typeable a => UnjsonDef a -> TypeRep
unjsonDefType _ = typeRep (Proxy @a)
```
We can then use these functions to define the Schemas (snippet from our codebase):
```haskell
import           Data.Swagger
import           Data.Unjson
import           Data.Unjson.Swagger

data Paper = Paper
  { paperCode :: Text
  , paperName :: Text
  } deriving (Show, Eq, Generic, Data)

samplePaper :: Paper
samplePaper = Paper
  { paperCode = "HBL"
  , paperName = "HUFVUDSTADSBLADET"
  }

instance ToSchema Paper where
  declareNamedSchema _ = do
    unjsonDefNamedSchema (unjsonDef @Paper)
      <&> schema.example ?~ unjsonToJSON unjsonDef samplePaper

instance Unjson Paper where
  unjsonDef = objectOf $ Paper
    <$> field "code" paperCode "Identifying code of the paper"
    <*> field "name" paperName "The name of the paper"

-- Package contains a Paper object
data Package = Package
  { packageName        :: Text
  , packagePaper       :: Paper
  } deriving (Show, Eq, Generic, Data)

samplePackage :: Package
samplePackage = Package
  { packageName        = "HBL 365"
  , packagePaper       = samplePaper
  }

instance ToSchema Package where
  declareNamedSchema _ = do
    unjsonDefNamedSchema (unjsonDef @Package)
      <&> schema.example ?~ unjsonToJSON unjsonDef samplePackage

instance Unjson Package where
  unjsonDef = objectOf $ Package
    <$> field    "name"        packageName        "Package name"
    <*> field    "paper"       packagePaper       "Paper associated with the package"
```

And then the generated Swagger schema will look like this:
<img width="817" alt="image" src="https://user-images.githubusercontent.com/5480361/35440020-3aabe2ae-02a6-11e8-846b-88dae982ab9e.png">



### Final Notes
We've had the `Data.Unjson.Swagger` lib in production for a while now, and we plan to cover all the corner cases we did not need (not many) and then release it.

We wanted to get our changes upstream before doing that, in case you have any opinion about a better solution to solve this object-references problem - we tried some other things, and they were all uglier or more complicated than this - we find `Typeable` very nice because it is already defined in `base` on all types. What do you think?