### PR TITLE
Automatic Enum representation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,6 @@ before_cache:
 
 matrix:
   include:
-    - compiler: "ghc-7.6.3"
-    # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.6.3], sources: [hvr-ghc]}}
     - compiler: "ghc-7.8.4"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.8.4], sources: [hvr-ghc]}}

--- a/src/Data/Unjson.hs
+++ b/src/Data/Unjson.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE TypeApplications #-}
 #if __GLASGOW_HASKELL__ < 710
 {-# LANGUAGE OverlappingInstances #-}
 #endif
@@ -1270,7 +1269,7 @@ enumUnjsonDef
   => UnjsonDef a
 enumUnjsonDef = enumOf typeName [ (Text.pack $ show $ toConstr c, c) | c <- constructors ]
   where
-    typeName = Text.pack . show . typeRep $ Proxy @a
+    typeName = Text.pack . show . typeRep $ (Proxy :: Proxy a)
     constructors = enumFromTo minBound maxBound :: [a]
 
 -- | Declare array of values where each of them is described by

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -435,10 +435,10 @@ test_enum_field = "test_enum_field" ~: do
                  ]
     let Result val iss = parse unjsonEnumAB json
     assertEqual "No problems" [Anchored (Path [PathElemKey "mode"]) "value 'wrong' is not one of the allowed for enumeration [A,B]"] iss
- 
+
 
 data AutoAB = AutoA | AutoB
-   deriving (Show, Eq, Ord, Enum, Bounded, Data)
+   deriving (Show, Eq, Ord, Enum, Bounded, Data, Typeable)
 
 unjsonAutoEnumAB :: UnjsonDef AutoAB
 unjsonAutoEnumAB = enumUnjsonDef

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -404,15 +404,14 @@ test_parse_either_field = "test_parse_either_field" ~: do
     assertBool "Documentation generates" (length docstr > 0)
   return ()
 
+
 data AB = A | B
    deriving (Show, Eq, Ord)
-
 
 unjsonEnumAB :: UnjsonDef AB
 unjsonEnumAB = enumOf "mode"
                      [ ("A", A)
                      , ("B", B)]
-
 
 test_enum_field :: Test
 test_enum_field = "test_enum_field" ~: do
@@ -436,6 +435,37 @@ test_enum_field = "test_enum_field" ~: do
                  ]
     let Result val iss = parse unjsonEnumAB json
     assertEqual "No problems" [Anchored (Path [PathElemKey "mode"]) "value 'wrong' is not one of the allowed for enumeration [A,B]"] iss
+ 
+
+data AutoAB = AutoA | AutoB
+   deriving (Show, Eq, Ord, Enum, Bounded, Data)
+
+unjsonAutoEnumAB :: UnjsonDef AutoAB
+unjsonAutoEnumAB = enumUnjsonDef
+
+test_auto_enum_field :: Test
+test_auto_enum_field = "test_auto_enum_field" ~: do
+  do
+    let json = Aeson.object
+                 [ "AutoAB" .= "AutoA"
+                 ]
+    let Result val iss = parse unjsonAutoEnumAB json
+    assertEqual "No problems" [] iss
+    assertEqual "Proper value present" AutoA val
+  do
+    let json = Aeson.object
+                 [ "AutoAB" .= "AutoB"
+                 ]
+    let Result val iss = parse unjsonAutoEnumAB json
+    assertEqual "No problems" [] iss
+    assertEqual "Proper value present" AutoB val
+  do
+    let json = Aeson.object
+                 [ "AutoAB" .= "wrong"
+                 ]
+    let Result val iss = parse unjsonAutoEnumAB json
+    assertEqual "No problems" [Anchored (Path [PathElemKey "AutoAB"]) "value 'wrong' is not one of the allowed for enumeration [AutoA,AutoB]"] iss
+    
 
 test_update_from_serialization :: Test
 test_update_from_serialization = "test_update_from_serialization" ~: do

--- a/unjson.cabal
+++ b/unjson.cabal
@@ -15,8 +15,8 @@ category:            Data
 build-type:          Simple
 extra-source-files:  README.md
 cabal-version:       >=1.18
-tested-with:         GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.3,
-                     GHC == 8.0.2, GHC == 8.2.2
+tested-with:         GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.2,
+                     GHC == 8.2.2
 
 source-repository head
   type:     git


### PR DESCRIPTION
We thought that writing enum representations by hand was a lot of characters (our domain has quite a lot of sum types in some places), so we automated it.

Example from our codebase:
```haskell
data SubscriptionState
  = Upcoming
  | Active
  | Canceled
  deriving (Show, Eq, Generic, Data, Enum, Bounded)
```

Before defining `enumUnjsonDef` we had to write this:
```haskell
instance Unjson SubscriptionState where
  unjsonDef = enumOf "SubscriptionState"
    [ ("Upcoming", Upcoming)
    , ("Active"  , Active)
    , ("Canceled", Canceled)
    ]
```

After:
```haskell
instance Unjson SubscriptionState where
  unjsonDef = enumUnjsonDef
```

Downsides of this: pulls in the `TypeApplication` extension, which was introduced in GHC 8.0. But if this is a problem I guess we could just add some other `ifs` on the GHC version to pull this in when possible.